### PR TITLE
Added All Builders Profile in Homepage

### DIFF
--- a/packages/nextjs/pages/builders/0xdDE7B987A01717EEfCcA1Dc5280c164E2cCD133e.tsx
+++ b/packages/nextjs/pages/builders/0xdDE7B987A01717EEfCcA1Dc5280c164E2cCD133e.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { Address } from "~~/components/scaffold-eth";
+
+const socials = [
+  {
+    link: "https://github.com/Chinwuba22",
+    title: "Github",
+  },
+  {
+    link: "https://twitter.com/Uba__X",
+    title: "Twitter",
+  },
+];
+
+const MyProfile = () => {
+  return (
+    <section className="flex justify-center items-center mt-10">
+      <div className="border flex gap-6 flex-col w-96 items-center border-white rounded-md p-5">
+        <Address address="0xdDE7B987A01717EEfCcA1Dc5280c164E2cCD133e" size="3xl" />
+        <p className="text-center">
+          {" "}
+          Curently exploring blockchain tech with key focus on security researching and building. Currently undergoing
+          the speedrun ethereum knowledge to help improve my building skills as well as connect with other like minded
+          individuals.{" "}
+        </p>
+        <div className="flex justify-around items-center w-full">
+          {socials.map(social => (
+            <Link className="text-blue-300 underline" key={social.title} href={social.link}>
+              {social.title}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MyProfile;

--- a/packages/nextjs/pages/builders/Allbuilders.tsx
+++ b/packages/nextjs/pages/builders/Allbuilders.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { Address } from "~~/components/scaffold-eth";
+
+const AllBuilders = [
+  "0xF51cFA5eb9128F064eafb75524502A039F063D91",
+  "0xdDE7B987A01717EEfCcA1Dc5280c164E2cCD133e",
+  "0x38D9cFf58D233AF0B9c1434EEDE012009D23c971",
+  "0xfbce2693fbed73e3d464d662235dc5adc5454c01",
+  //"0x5638bf706056d01b2dab817915244b3e21a56fe8",
+  //"0xc863dfee737c803c93af4b6b27029294f6a56eb5",
+  //"0x0235008236ca99e4dbcaa234c1065db7c91afeac",
+  //"0xfc7bc662fa06137f769366a46b19924371e880bd",
+  //"0x63191383edbd8531c442868d87555f1ea2f6ad4e",
+  //"0x63a32f1595a68e811496d820680b74a5cca303c5",
+  //"0xca6894423940ab96828c50cc97a9f24b5e7c8016",
+  //"0xd6c7be821cbf10af04c297b35e67552081c6bce9",
+  //"0xe4a98d2bfd66ce08128fdfffc9070662e489a28e",
+  //"0x1e7aabb9d0c701208e875131d0a1cfcdaba79350",  ADDRESSES WILL BE UNCOMMENTED WHEN THEY MAKE AN UPLOAD
+];
+
+const fileExists = (address: string) => {
+  return true;
+};
+
+const Allbuilders = () => {
+  return (
+    <section className=" text-center mt-10">
+      <h1 className="text-2xl font-bold mb-4">
+        Click any of the addresses Below To Navigate to the Profile of Each builder
+      </h1>
+      <ul className=" link grid grid-cols-1 gap-4">
+        {AllBuilders.map(builderAddress => (
+          <li key={builderAddress} bg-gray-200 p-4 rounded-md>
+            {fileExists(builderAddress) ? (
+              <Link href={`${builderAddress.toString()}`}>{builderAddress}</Link>
+            ) : (
+              <span>Builder is yet to upload a personal page</span>
+            )}
+          </li>
+        ))}
+      </ul>
+      <h2 className="font-bold gap-2 text-2xl mt-8">Other Builders profile would be updated with time....</h2>
+    </section>
+  );
+};
+
+export default Allbuilders;

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -26,6 +26,12 @@ const Home: NextPage = () => {
             <span className="font-bold">Checked in builders count:</span>
             <span> {checkedInCount?.toString() ?? loadingSpinner}</span>
           </p>
+          <p className="text-lg flex gap-2 justify-center">
+            <Link href="./builders/Allbuilders" className="link font-bold">
+              Click Here
+            </Link>{" "}
+            to check out the personal page of each builders. {""}
+          </p>
         </div>
 
         <div className="flex-grow bg-base-300 w-full mt-16 px-8 py-12">


### PR DESCRIPTION
## Description
I added a section in the index.tsx that directs users to all the builder's profile;
<img width="363" alt="image" src="https://github.com/BuidlGuidl/batch0.buidlguidl.com/assets/111384287/504e15ba-d895-44c2-926c-cc3157c0b39f">
When the "click here" is tapped, it directs the operator to:
<img width="689" alt="image" src="https://github.com/BuidlGuidl/batch0.buidlguidl.com/assets/111384287/88d8ade0-469f-410f-a720-f830ec0b6c61">

The operator then clicks any address to view the profile.
Also added my profile.



## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: akwuba.eth
