### PR TITLE
Add builders tab to show members

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -18,6 +18,10 @@ export const menuLinks: HeaderMenuLink[] = [
     href: "/",
   },
   {
+    label: "Builders",
+    href: "/builders",
+  },
+  {
     label: "Debug Contracts",
     href: "/debug",
     icon: <BugAntIcon className="h-4 w-4" />,

--- a/packages/nextjs/pages/builders.tsx
+++ b/packages/nextjs/pages/builders.tsx
@@ -1,7 +1,29 @@
+import Link from "next/link";
 import { NextPage } from "next";
 import { Spinner } from "~~/components/assets/Spinner";
 import { Address } from "~~/components/scaffold-eth";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth/useScaffoldEventHistory";
+
+const LargeSpinner = () => {
+  return (
+    <div className="my-24 flex justify-center">
+      <Spinner width="50" height="50" />
+    </div>
+  );
+};
+
+const BuilderTile = (address: string) => {
+  return (
+    <Link
+      key={address}
+      href={`/builders/${address}`}
+      className="px-4 py-2 flex justify-center rounded hover:ring-2 transition duration-300 ease-in-out"
+      passHref
+    >
+      <Address disableAddressLink={true} size="lg" format="long" address={address} />
+    </Link>
+  );
+};
 
 const BuildersList: NextPage = () => {
   const { data: buildersList, isLoading: isBuildersListLoading } = useScaffoldEventHistory({
@@ -10,24 +32,6 @@ const BuildersList: NextPage = () => {
     fromBlock: 113342437n,
   });
 
-  const spinner = (
-    <div className="my-24 flex justify-center">
-      <Spinner width="50" height="50" />
-    </div>
-  );
-
-  const builderTile = (address: string) => {
-    return (
-      <a
-        key={address}
-        href={`/builders/${address}`}
-        className="px-4 py-2 flex justify-center rounded hover:ring-2 transition duration-300 ease-in-out"
-      >
-        <Address disableAddressLink={true} size="lg" format="long" address={address} />
-      </a>
-    );
-  };
-
   return (
     <div className="mt-16 flex items-center justify-center">
       <div className="container md:max-w-xl mx-4 shadow-xl rounded-lg">
@@ -35,9 +39,9 @@ const BuildersList: NextPage = () => {
           👷‍♂️ Builders 🔨
         </h2>
         {isBuildersListLoading ? (
-          spinner
+          <LargeSpinner />
         ) : (
-          <div className="flex flex-col">{buildersList?.map(builder => builderTile(builder.args[1]))}</div>
+          <div className="flex flex-col">{buildersList?.map(builder => BuilderTile(builder.args[1]))}</div>
         )}
       </div>
     </div>

--- a/packages/nextjs/pages/builders.tsx
+++ b/packages/nextjs/pages/builders.tsx
@@ -1,0 +1,47 @@
+import { NextPage } from "next";
+import { Spinner } from "~~/components/assets/Spinner";
+import { Address } from "~~/components/scaffold-eth";
+import { useScaffoldEventHistory } from "~~/hooks/scaffold-eth/useScaffoldEventHistory";
+
+const BuildersList: NextPage = () => {
+  const { data: buildersList, isLoading: isBuildersListLoading } = useScaffoldEventHistory({
+    contractName: "BatchRegistry",
+    eventName: "CheckedIn",
+    fromBlock: 113342437n,
+  });
+
+  const spinner = (
+    <div className="my-24 flex justify-center">
+      <Spinner width="50" height="50" />
+    </div>
+  );
+
+  const builderTile = (address: string) => {
+    return (
+      <a
+        key={address}
+        href={`/builders/${address}`}
+        className="px-4 py-2 flex justify-center rounded hover:ring-2 transition duration-300 ease-in-out"
+      >
+        <Address disableAddressLink={true} size="lg" format="long" address={address} />
+      </a>
+    );
+  };
+
+  return (
+    <div className="mt-16 flex items-center justify-center">
+      <div className="container md:max-w-xl mx-4 shadow-xl rounded-lg">
+        <h2 className="flex justify-center font-mono rounded-t-lg text-lg font-bold py-2 bg-base-300">
+          👷‍♂️ Builders 🔨
+        </h2>
+        {isBuildersListLoading ? (
+          spinner
+        ) : (
+          <div className="flex flex-col">{buildersList?.map(builder => builderTile(builder.args[1]))}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BuildersList;


### PR DESCRIPTION
## Description

Adds a builders tab to show checked in members.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #3_

Your ENS/address: **solo1g.eth**